### PR TITLE
feature: Support querying for events without aggregate id filter

### DIFF
--- a/cqrs-core/src/store.rs
+++ b/cqrs-core/src/store.rs
@@ -18,6 +18,19 @@ where
     /// The error type.
     type Error: CqrsError;
 
+    /// Helper function for reading events from the source
+    ///
+    /// Only loads events after the event number provided in `since` (See [Since]), and will only load a maximum of
+    /// `max_count` events, if given. If not given, will read all remaining events.
+    fn _read_events<I>(
+        &self,
+        id: Option<&I>,
+        since: Since,
+        max_count: Option<u64>,
+    ) -> Result<Option<Self::Events>, Self::Error>
+    where
+        I: AggregateId<A>;
+
     /// Reads events from the event source for a given identifier.
     ///
     /// Only loads events after the event number provided in `since` (See [Since]), and will only load a maximum of
@@ -29,7 +42,25 @@ where
         max_count: Option<u64>,
     ) -> Result<Option<Self::Events>, Self::Error>
     where
-        I: AggregateId<A>;
+        I: AggregateId<A>,
+    {
+        self._read_events(Some(id), since, max_count)
+    }
+
+    /// Reads _all_ events from the event source
+    ///
+    /// Only loads events after the event number provided in `since` (See [Since]), and will only load a maximum of
+    /// `max_count` events, if given. If not given, will read all remaining events.
+    fn read_all_events<I>(
+        &self,
+        since: Since,
+        max_count: Option<u64>,
+    ) -> Result<Option<Self::Events>, Self::Error> 
+    where
+        I: AggregateId<A>,
+    {
+        self._read_events(None::<&I>, since, max_count)
+    }
 }
 
 /// A sink for writing/persisting events with associated metadata.

--- a/cqrs/src/entity.rs
+++ b/cqrs/src/entity.rs
@@ -557,16 +557,16 @@ where
     type Error = ES::Error;
     type Events = ES::Events;
 
-    fn read_events<I>(
+    fn _read_events<I>(
         &self,
-        id: &I,
+        id: Option<&I>,
         since: Since,
         max_count: Option<u64>,
     ) -> Result<Option<Self::Events>, Self::Error>
     where
         I: AggregateId<A>,
     {
-        self.event_source.read_events(id, since, max_count)
+        self.event_source._read_events(id, since, max_count)
     }
 }
 
@@ -790,16 +790,16 @@ where
     type Error = <ES as EventSource<A, E>>::Error;
     type Events = <ES as EventSource<A, E>>::Events;
 
-    fn read_events<I>(
+    fn _read_events<I>(
         &self,
-        id: &I,
+        id: Option<&I>,
         since: Since,
         max_count: Option<u64>,
     ) -> Result<Option<Self::Events>, Self::Error>
     where
         I: AggregateId<A>,
     {
-        self.entity_source.read_events(id, since, max_count)
+        self.entity_source._read_events(id, since, max_count)
     }
 }
 

--- a/cqrs/src/trivial.rs
+++ b/cqrs/src/trivial.rs
@@ -54,9 +54,9 @@ where
     type Events = Empty<VersionedEvent<E>>;
 
     #[inline]
-    fn read_events<I>(
+    fn _read_events<I>(
         &self,
-        _id: &I,
+        _id: Option<&I>,
         _version: Since,
         _max_count: Option<u64>,
     ) -> Result<Option<Self::Events>, Self::Error>


### PR DESCRIPTION
This refactors "raw" event reading such that the ID is optional. The same `read_events` interface with a required ID is provided, which now just wraps the `_read_events` function, passing `Some(&id)`, and a new `read_all_events` function is exposed for reading all events (provided the same "limit/offset" filters as the original `read_events` function). 

Reading all events is used for cross-aggregate (but not cross-domain!) projections, also frequently called "group-by" projections. Think things like "give me the user ID for the user with this email", or "give me all the projects owned by this user", etc. 

Eventually, these sorts of queries ought to be served by a SQL-speaking read model, but for the moment this drastically improves query performance over the previous solution, which was to first read all entity IDs for a particular aggregate type, and then read the events for each entity one-by-one.