### PR TITLE
Expose aggregate ID of event

### DIFF
--- a/cqrs-core/src/types.rs
+++ b/cqrs-core/src/types.rs
@@ -221,13 +221,19 @@ impl fmt::Display for Precondition {
 }
 
 /// A structured tuple combining an event number and an event.
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct VersionedEvent<E> {
     /// The event number.
     pub sequence: EventNumber,
 
     /// The event.
     pub event: E,
+    
+    // The aggregate type for events resulting from queries over multiple aggregate types
+    pub aggregate_type: String,
+    
+    // The aggregate ID for events resulting from queries over multiple aggregates
+    pub aggregate_id: String
 }
 
 /// A structured tuple combining an event number and an event.

--- a/cqrs/src/memory.rs
+++ b/cqrs/src/memory.rs
@@ -188,6 +188,8 @@ where
                 let versioned_event = VersionedEvent {
                     sequence,
                     event: event.to_owned(),
+                    aggregate_id: id.as_str().to_owned(),
+                    aggregate_type: A::aggregate_type().to_owned(),
                 };
                 sequence.incr();
                 versioned_event
@@ -211,6 +213,8 @@ where
                         let versioned_event = VersionedEvent {
                             sequence,
                             event: event.to_owned(),
+                            aggregate_id: id.as_str().to_owned(),
+                            aggregate_type: A::aggregate_type().to_owned(),
                         };
                         sequence.incr();
                         versioned_event

--- a/cqrs/tests/load_exec_persist.rs
+++ b/cqrs/tests/load_exec_persist.rs
@@ -3,9 +3,7 @@ use std::{
     collections::{hash_map::Entry, HashMap},
 };
 
-use cqrs::{
-    AggregateId, EventNumber, EventSink, EventSource, Precondition, Since, Version, VersionedEvent,
-};
+use cqrs::{Aggregate, AggregateId, EventNumber, EventSink, EventSource, Precondition, Since, Version, VersionedEvent};
 use cqrs_todo_core::{TodoAggregate, TodoEvent, TodoIdRef, TodoMetadata};
 use void::Void;
 
@@ -122,6 +120,8 @@ impl EventSink<TodoAggregate, TodoEvent, TodoMetadata> for EventMap {
             stream.push(VersionedEvent {
                 sequence: sequence.event_number().unwrap(),
                 event: event.to_owned(),
+                aggregate_id: id.as_str().to_owned(),
+                aggregate_type: TodoAggregate::aggregate_type().to_owned()
             });
             sequence.incr();
         }
@@ -171,10 +171,14 @@ fn main_test() {
         VersionedEvent {
             sequence: EventNumber::MIN_VALUE,
             event: cqrs_todo_core::TodoEvent::Completed(cqrs_todo_core::events::Completed {}),
+            aggregate_id: id.as_str().to_owned(),
+            aggregate_type: TodoAggregate::aggregate_type().to_owned()
         },
         VersionedEvent {
             sequence: EventNumber::MIN_VALUE.next(),
             event: cqrs_todo_core::TodoEvent::Uncompleted(cqrs_todo_core::events::Uncompleted {}),
+            aggregate_id: id.as_str().to_owned(),
+            aggregate_type: TodoAggregate::aggregate_type().to_owned()
         },
     ];
 


### PR DESCRIPTION
Now that we can [read all events for an aggregate](https://github.com/opticdev/cqrs/pull/1), the entity ID isn't known at query time, like it was before. This means that in order to know the entity ID for a particular event read from the datastore, that ID must be explicitly included in the event metadata, which it wasn't originally.

The majority of the changes here are boilerplate to satisfy the Rust borrow checker. The meat is [here](https://github.com/opticdev/cqrs/compare/feature/read_all_events...opticdev:refactor/aggregate_id#diff-faa3b5db35c578f5b2e123405c6e4b3dcbcebf6cbbd06c5b3dad990756088dcbR613-R688) where we actually query for the entity ID and return it.