### PR TITLE
introduce the concept of execution environment

### DIFF
--- a/cqrs-core/src/lib.rs
+++ b/cqrs-core/src/lib.rs
@@ -17,6 +17,7 @@
 extern crate void;
 
 mod aggregate;
+
 pub mod reactor;
 mod store;
 mod types;
@@ -24,7 +25,7 @@ mod types;
 #[doc(inline)]
 pub use crate::aggregate::{
     Aggregate, AggregateCommand, AggregateEvent, AggregateId, CommandError, DeserializableEvent,
-    Event, Events, ProducedEvent, ProducedEvents, SerializableEvent,
+    Event, Events, ProducedEvent, ProducedEvents, SerializableEvent, CommandHandlerEnv,
 };
 #[doc(inline)]
 pub use crate::store::{

--- a/cqrs-core/src/store.rs
+++ b/cqrs-core/src/store.rs
@@ -55,7 +55,7 @@ where
         &self,
         since: Since,
         max_count: Option<u64>,
-    ) -> Result<Option<Self::Events>, Self::Error> 
+    ) -> Result<Option<Self::Events>, Self::Error>
     where
         I: AggregateId<A>,
     {
@@ -186,8 +186,9 @@ mod tests {
         type Error = Void;
         type Event = TestEvent;
         type Events = Vec<TestEvent>;
+        type Env = ();
 
-        fn execute_on(self, _aggregate: &TestAggregate) -> Result<Self::Events, Self::Error> {
+        fn execute_on(self, _aggregate: &TestAggregate, env: Option<&mut Self::Env>) -> Result<Self::Events, Self::Error> {
             Ok(Vec::default())
         }
     }

--- a/cqrs-todo-core/src/commands.rs
+++ b/cqrs-todo-core/src/commands.rs
@@ -18,13 +18,16 @@ pub struct CreateTodo {
     /// The initial reminder to set. `None` indicates no initial reminder.
     pub reminder: Option<domain::Reminder>,
 }
-
 impl AggregateCommand<TodoAggregate> for CreateTodo {
     type Error = CommandError;
     type Event = TodoEvent;
     type Events = ArrayVec<[Self::Event; 2]>;
-
-    fn execute_on(self, aggregate: &TodoAggregate) -> Result<Self::Events, Self::Error> {
+    type Env = ();
+    fn execute_on(
+        self,
+        aggregate: &TodoAggregate,
+        env: Option<&mut ()>,
+    ) -> Result<Self::Events, Self::Error> {
         if let TodoAggregate::Created(_) = aggregate {
             return Err(CommandError::AlreadyCreated);
         }
@@ -53,8 +56,13 @@ impl AggregateCommand<TodoAggregate> for UpdateDescription {
     type Error = CommandError;
     type Event = TodoEvent;
     type Events = ArrayVec<[Self::Event; 1]>;
+    type Env = ();
 
-    fn execute_on(self, aggregate: &TodoAggregate) -> Result<Self::Events, Self::Error> {
+    fn execute_on(
+        self,
+        aggregate: &TodoAggregate,
+        env: Option<&mut ()>,
+    ) -> Result<Self::Events, Self::Error> {
         if let TodoAggregate::Created(ref data) = aggregate {
             if data.description != self.new_description {
                 let mut events = ArrayVec::new();
@@ -82,8 +90,12 @@ impl AggregateCommand<TodoAggregate> for SetReminder {
     type Error = CommandError;
     type Event = TodoEvent;
     type Events = ArrayVec<[Self::Event; 1]>;
-
-    fn execute_on(self, aggregate: &TodoAggregate) -> Result<Self::Events, Self::Error> {
+    type Env = ();
+    fn execute_on(
+        self,
+        aggregate: &TodoAggregate,
+        env: Option<&mut ()>,
+    ) -> Result<Self::Events, Self::Error> {
         if let TodoAggregate::Created(ref data) = aggregate {
             let new_reminder = Some(self.new_reminder);
 
@@ -108,8 +120,12 @@ impl AggregateCommand<TodoAggregate> for CancelReminder {
     type Error = CommandError;
     type Event = TodoEvent;
     type Events = ArrayVec<[Self::Event; 1]>;
-
-    fn execute_on(self, aggregate: &TodoAggregate) -> Result<Self::Events, Self::Error> {
+    type Env = ();
+    fn execute_on(
+        self,
+        aggregate: &TodoAggregate,
+        env: Option<&mut ()>,
+    ) -> Result<Self::Events, Self::Error> {
         if let TodoAggregate::Created(ref data) = aggregate {
             if data.reminder.is_some() {
                 let mut events = ArrayVec::new();
@@ -134,8 +150,12 @@ impl AggregateCommand<TodoAggregate> for ToggleCompletion {
     type Error = CommandError;
     type Event = TodoEvent;
     type Events = ArrayVec<[Self::Event; 1]>;
-
-    fn execute_on(self, aggregate: &TodoAggregate) -> Result<Self::Events, Self::Error> {
+    type Env = ();
+    fn execute_on(
+        self,
+        aggregate: &TodoAggregate,
+        env: Option<&mut ()>,
+    ) -> Result<Self::Events, Self::Error> {
         if let TodoAggregate::Created(ref data) = aggregate {
             let mut events = ArrayVec::new();
             match data.status {
@@ -157,8 +177,12 @@ impl AggregateCommand<TodoAggregate> for MarkCompleted {
     type Error = CommandError;
     type Event = TodoEvent;
     type Events = ArrayVec<[Self::Event; 1]>;
-
-    fn execute_on(self, aggregate: &TodoAggregate) -> Result<Self::Events, Self::Error> {
+    type Env = ();
+    fn execute_on(
+        self,
+        aggregate: &TodoAggregate,
+        env: Option<&mut ()>,
+    ) -> Result<Self::Events, Self::Error> {
         if let TodoAggregate::Created(ref data) = aggregate {
             let mut events = ArrayVec::new();
             if data.status == TodoStatus::NotCompleted {
@@ -179,8 +203,12 @@ impl AggregateCommand<TodoAggregate> for ResetCompleted {
     type Error = CommandError;
     type Event = TodoEvent;
     type Events = ArrayVec<[Self::Event; 1]>;
-
-    fn execute_on(self, aggregate: &TodoAggregate) -> Result<Self::Events, Self::Error> {
+    type Env = ();
+    fn execute_on(
+        self,
+        aggregate: &TodoAggregate,
+        env: Option<&mut ()>,
+    ) -> Result<Self::Events, Self::Error> {
         if let TodoAggregate::Created(ref data) = aggregate {
             let mut events = ArrayVec::new();
             if data.status == TodoStatus::Completed {

--- a/cqrs-todo-core/src/lib.rs
+++ b/cqrs-todo-core/src/lib.rs
@@ -263,6 +263,7 @@ mod tests {
     use chrono::{Duration, TimeZone, Utc};
     use pretty_assertions::assert_eq;
 
+
     fn create_basic_aggregate() -> TodoAggregate {
         let now = Utc.ymd(1970, 1, 1).and_hms(0, 0, 0);
         let reminder = now + Duration::seconds(10000);
@@ -311,7 +312,7 @@ mod tests {
 
         let cmd = commands::CancelReminder;
 
-        let result = agg.execute(cmd).unwrap_err();
+        let result = agg.execute::<>(cmd, None).unwrap_err();
 
         assert_eq!(error::CommandError::NotInitialized, result);
     }
@@ -322,7 +323,7 @@ mod tests {
 
         let cmd = commands::CancelReminder;
 
-        let result = agg.execute(cmd).unwrap();
+        let result = agg.execute(cmd, None).unwrap();
 
         assert_eq!(ArrayVec::new(), result);
     }
@@ -336,7 +337,7 @@ mod tests {
         let new_reminder = domain::Reminder::new(reminder_time, now).unwrap();
         let cmd = commands::SetReminder { new_reminder };
 
-        let result = agg.execute(cmd).unwrap();
+        let result = agg.execute::<>(cmd, None).unwrap();
 
         let mut expected = ArrayVec::new();
         expected.push(TodoEvent::ReminderUpdated(events::ReminderUpdated {

--- a/cqrs/src/entity.rs
+++ b/cqrs/src/entity.rs
@@ -390,7 +390,7 @@ where
 
         let expected_version = aggregate.version;
 
-        match aggregate.state.execute(command) {
+        match aggregate.state.execute(command, None) {
             Ok(events) => {
                 self.apply_events_and_persist(
                     id,

--- a/cqrs/src/testing.rs
+++ b/cqrs/src/testing.rs
@@ -37,8 +37,9 @@ impl AggregateCommand<TestAggregate> for TestCommand {
     type Error = Void;
     type Event = TestEvent;
     type Events = Vec<TestEvent>;
+    type Env = ();
 
-    fn execute_on(self, _aggregate: &TestAggregate) -> Result<Self::Events, Self::Error> {
+    fn execute_on(self, _aggregate: &TestAggregate, env: Option<&mut Self::Env>) -> Result<Self::Events, Self::Error> {
         Ok(Vec::new())
     }
 }


### PR DESCRIPTION
## 🍗 Description
* adds the concept of execution environment so whoever invokes a command on an aggregate can provide some state. This is necessary because the trait hierarchy imposes a lot of restrictions on the Aggregate for persistence reasons (which makes it difficult to put arbitrary state on those structs

## 📚 References
This is to support work in monorail related to testing and other functionality

## 👹 QA
- [x] We don't have any CI stuff but I verified `cargo test` passes and it works with my changes on monorail

## Later...
- [ ] move this code into monorail, add ci tests etc.