### PR TITLE
fix when events have been deleted

### DIFF
--- a/cqrs/Cargo.toml
+++ b/cqrs/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 cqrs-core = { version = "0.2.2", path = "../cqrs-core" }
 parking_lot = "0.9"
 void = "1.0"
+log = "0.4.14"
 
 [dev-dependencies]
 static_assertions = "0.3"

--- a/cqrs/src/entity.rs
+++ b/cqrs/src/entity.rs
@@ -217,8 +217,10 @@ where
         if let Some(seq_events) = seq_events {
             for seq_event in seq_events {
                 aggregate.apply(seq_event.event);
-
-                debug_assert_eq!(Version::Number(seq_event.sequence), aggregate.version);
+                if Version::Number(seq_event.sequence) != aggregate.version {
+                    eprintln!("mismatched event number {}/{} {} {}", seq_event.sequence, aggregate.version, A::aggregate_type().to_string(), id.as_str())
+                }
+                //debug_assert_eq!(Version::Number(seq_event.sequence), aggregate.version);
             }
         }
 

--- a/cqrs/src/entity.rs
+++ b/cqrs/src/entity.rs
@@ -218,7 +218,7 @@ where
             for seq_event in seq_events {
                 aggregate.apply(seq_event.event);
                 if Version::Number(seq_event.sequence) != aggregate.version {
-                    eprintln!("mismatched event number {}/{} {} {}", seq_event.sequence, aggregate.version, A::aggregate_type().to_string(), id.as_str())
+                    log::warn!("mismatched event number {}/{} {} {}", seq_event.sequence, aggregate.version, A::aggregate_type().to_string(), id.as_str())
                 }
                 //debug_assert_eq!(Version::Number(seq_event.sequence), aggregate.version);
             }


### PR DESCRIPTION
when rehydrating an aggregate, if events are missing, the event number will not match the sequence number.
since we are running debug builds, the debug_assert causes failures. this changes it to log a useful message